### PR TITLE
Missing a return statement on alias of isLeyeredNavigationAvailable

### DIFF
--- a/app/code/community/JR/Search/Model/Resource/Engine/Abstract.php
+++ b/app/code/community/JR/Search/Model/Resource/Engine/Abstract.php
@@ -216,7 +216,7 @@ abstract class JR_Search_Model_Resource_Engine_Abstract
      */
     public function isLeyeredNavigationAllowed()
     {
-        $this->isLayeredNavigationAllowed();
+        return $this->isLayeredNavigationAllowed();
     }
 
     /**


### PR DESCRIPTION
Was causing problems with Amasty plugin not showing filters in search results.
