### PR TITLE
Don't use ES product collections when indexing

### DIFF
--- a/app/code/community/Bubble/Search/Helper/Data.php
+++ b/app/code/community/Bubble/Search/Helper/Data.php
@@ -387,6 +387,22 @@ class Bubble_Search_Helper_Data extends Mage_Core_Helper_Abstract
 
         return $default;
     }
+    
+    /**
+     * Get Status of catalogsearch_fulltext index
+     *
+     * @return string
+     */
+    public function getIndexStatus()
+    {
+        if (!($indexStatus = Mage::registry('bubble_search.index_status'))) {
+            $indexStatus = Mage::getSingleton('index/indexer')
+                ->getProcessByCode('catalogsearch_fulltext')
+                ->getStatus();
+            Mage::register('bubble_search.index_status', $indexStatus);
+        }
+        return $indexStatus;
+    }
 
     /**
      * Checks if configured engine is active.
@@ -400,6 +416,7 @@ class Bubble_Search_Helper_Data extends Mage_Core_Helper_Abstract
             $model = Mage::getResourceSingleton($engine);
             return $model
                 && $model instanceof Bubble_Search_Model_Resource_Engine_Abstract
+                && ($this->getIndexStatus() != 'working')
                 && $model->test();
         }
 


### PR DESCRIPTION
I was getting empty product collections on anchor categories while the index was running. 

P.S. I'm actually using the paid version, so just copied the changes I made to my version. 
It's a great base to start some heavy customisations on, except that having no events to listen on (and the code being in the local pool) make it almost necessary to hack at some of the files. I'd love to add some more events into the code where it would allow me to do things like modify the query.
